### PR TITLE
added error handling so an agent can be in an error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.0
+
+* Adds `Agent.error` and `Agent.resetError`.
+* Adds protection from talking to killed Agents.
+* Updated naming of methods based on feedback:
+  - deref -> read
+  - query -> **eliminated for read**
+  - create -> **eliminated for new create**
+  - createWithResult -> create
+  - send -> update
+
 # 0.0.7
 
 * Adds `Agent.createWithResult`.

--- a/lib/isolate_agents.dart
+++ b/lib/isolate_agents.dart
@@ -9,33 +9,59 @@ class _Command {
   _Command(this.code, {this.sendPort, this.arg0});
 }
 
+class _Result<T> {
+  _Result({required this.value, required this.error});
+
+  final T value;
+  final Object? error;
+}
+
 enum _Commands {
   init,
   exec,
-  deref,
   exit,
   query,
+  getError,
+  resetError,
 }
 
 void _isolateMain<T>(SendPort sendPort) {
   ReceivePort receivePort = ReceivePort();
   sendPort.send(_Command(_Commands.init, arg0: receivePort.sendPort));
   late T state;
+  Object? error;
   receivePort.listen((value) {
     _Command command = value;
     if (command.code == _Commands.init) {
       state = (command.arg0 as T Function())();
     } else if (command.code == _Commands.exec) {
-      final func = command.arg0 as T Function(T);
-      state = func(state);
+      try {
+        final func = command.arg0 as T Function(T);
+        state = func(state);
+      } catch (e) {
+        error = e;
+      }
       command.sendPort!.send(null);
-    } else if (command.code == _Commands.deref) {
-      command.sendPort!.send(state);
     } else if (command.code == _Commands.exit) {
       Isolate.exit(command.sendPort!, state);
     } else if (command.code == _Commands.query) {
-      Object? Function(T) func = command.arg0 as Object? Function(T);
-      command.sendPort!.send(func(state));
+      Object? result;
+      try {
+        Object? Function(T) func = command.arg0 as Object? Function(T);
+        result = func(state);
+      } catch (e) {
+        error = e;
+      }
+      if (error != null) {
+        command.sendPort!.send(_Result<dynamic>(value: null, error: error));
+      } else {
+        command.sendPort!.send(_Result<dynamic>(value: result, error: null));
+      }
+    } else if (command.code == _Commands.getError) {
+      command.sendPort!.send(error);
+    } else if (command.code == _Commands.resetError) {
+      error = null;
+      command.sendPort!.send(null);
     }
   });
 }
@@ -45,13 +71,13 @@ void _isolateMain<T>(SendPort sendPort) {
 /// This is a convenient wrapper around having an isolate, dart ports and
 /// managing some state that is edited on the isolate.
 class Agent<T> {
-  final Isolate _isolate;
+  Isolate? _isolate;
   final SendPort _sendPort;
 
   Agent._(this._isolate, this._sendPort);
 
   /// Creates the [Agent] whose initial state is the result of executing [func].
-  static Future<Agent<T>> createWithResult<T>(T Function() func) async {
+  static Future<Agent<T>> create<T>(T Function() func) async {
     ReceivePort receivePort = ReceivePort();
     Isolate isolate =
         await Isolate.spawn(_isolateMain<T>, receivePort.sendPort);
@@ -67,53 +93,81 @@ class Agent<T> {
     return Agent<T>._(isolate, sendPort);
   }
 
-  /// Create the [Agent] with the initial value being [initialState].
-  ///
-  /// Note: It may be faster to use [createWithResult] since it avoids
-  /// sending the [initialState].
-  static Future<Agent<T>> create<T>(T initialState) async {
-    return createWithResult(() => initialState);
-  }
-
-  /// Send a closure that will be executed in the Agent's isolate.
-  Future<void> send(T Function(T) func) async {
+  /// Send a closure [func] that will be executed in the [Agent]'s [Isolate].
+  /// The result of [func] is assigned to the value of the [Agent].
+  Future<void> update(T Function(T) func) async {
+    if (_isolate == null) {
+      throw StateError('Agent has been killed.');
+    }
     ReceivePort receivePort = ReceivePort();
     _sendPort.send(
         _Command(_Commands.exec, sendPort: receivePort.sendPort, arg0: func));
     return receivePort.first;
   }
 
-  /// Query the current value of the agent.
-  Future<T> deref() async {
-    ReceivePort receivePort = ReceivePort();
-    _sendPort.send(_Command(_Commands.deref, sendPort: receivePort.sendPort));
-    dynamic value = await receivePort.first;
-    return value as T;
-  }
-
-  /// Queries the [Agent]'s state with a closure.
+  /// Reads the [Agent]'s state with a closure.
   ///
-  /// This is useful for reading a portion of the state held by the agent to
+  /// [query] is useful for reading a portion of the state held by the agent to
   /// avoid the overhead of reading the whole state.
-  Future<U> query<U>(U Function(T state) queryFunc) async {
+  Future<U> read<U>({U Function(T state)? query}) async {
+    if (_isolate == null) {
+      throw StateError('Agent has been killed.');
+    }
     ReceivePort receivePort = ReceivePort();
     _sendPort.send(_Command(_Commands.query,
-        sendPort: receivePort.sendPort, arg0: queryFunc));
-    dynamic value = await receivePort.first;
-    return value as U;
+        sendPort: receivePort.sendPort, arg0: query ?? (x) => x));
+    final _Result<dynamic> result = await receivePort.first;
+    if (result.error != null) {
+      throw result.error!;
+    } else {
+      return result.value as U;
+    }
   }
 
   /// Kills the agent and returns its state value. This is faster than calling
   /// [deref] then [kill] since Dart will elide the copy of the result.
   Future<T> exit() async {
+    // TODO(gaaclarke): Add an exit listener to the isolate so the state of all
+    // Agents can be cleared out.
+    if (_isolate == null) {
+      throw StateError('Agent has been killed.');
+    }
+    _isolate = null;
     ReceivePort receivePort = ReceivePort();
     _sendPort.send(_Command(_Commands.exit, sendPort: receivePort.sendPort));
     dynamic value = await receivePort.first;
     return value as T;
   }
 
-  /// Kills the agent's isolate.
+  /// Gets the current error associated with the Agent, null if there is none.
+  ///
+  /// See also:
+  ///   * [resetError]
+  Future<Object?> get error async {
+    if (_isolate == null) {
+      throw StateError('Agent has been killed.');
+    }
+    ReceivePort receivePort = ReceivePort();
+    _sendPort
+        .send(_Command(_Commands.getError, sendPort: receivePort.sendPort));
+    dynamic value = await receivePort.first;
+    return value as Object?;
+  }
+
+  /// Resets the [Agent] so it can start receiving messages again.
+  Future<void> resetError() async {
+    if (_isolate == null) {
+      throw StateError('Agent has been killed.');
+    }
+    ReceivePort receivePort = ReceivePort();
+    _sendPort
+        .send(_Command(_Commands.resetError, sendPort: receivePort.sendPort));
+    await receivePort.first;
+  }
+
+  /// Kills the [Agent]'s isolate. Any interaction with the Agent after this will
+  /// result in a [StateError].
   void kill() {
-    _isolate.kill();
+    _isolate = null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isolate_agents
 description: Agents are state that lives on a background isolate.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/gaaclarke/agents
 
 environment:

--- a/test/isolate_agents_test.dart
+++ b/test/isolate_agents_test.dart
@@ -5,32 +5,32 @@ import 'package:test/test.dart';
 
 void main() {
   test('simple', () async {
-    Agent<int> agent = await Agent.create(1);
-    agent.send((x) => x + 1);
-    expect(2, await agent.deref());
+    Agent<int> agent = await Agent.create(() => 1);
+    agent.update((x) => x + 1);
+    expect(2, await agent.read());
     agent.kill();
   });
 
   test('exit', () async {
-    Agent<int> agent = await Agent.create(1);
-    agent.send((x) => x + 1);
+    Agent<int> agent = await Agent.create(() => 1);
+    agent.update((x) => x + 1);
     expect(2, await agent.exit());
   });
 
   test('query', () async {
-    final Agent<int> agent = await Agent.create(1);
+    final Agent<int> agent = await Agent.create(() => 1);
     final String value =
-        await agent.query((state) => String.fromCharCode(65 + state));
+        await agent.read(query: (state) => String.fromCharCode(65 + state));
     expect('B', value);
   });
 
   test('hop agents', () async {
-    final Agent<int> agent1 = await Agent.create(1);
-    final Agent<int> agent2 = await Agent.create(2);
+    final Agent<int> agent1 = await Agent.create(() => 1);
+    final Agent<int> agent2 = await Agent.create(() => 2);
     ReceivePort receivePort = ReceivePort();
     SendPort sendPort = receivePort.sendPort;
-    agent1.send((x) {
-      agent2.send((y) {
+    agent1.update((x) {
+      agent2.update((y) {
         sendPort.send(x + y);
         return y;
       });
@@ -39,5 +39,73 @@ void main() {
 
     int result = (await receivePort.first) as int;
     expect(3, result);
+  });
+
+  test('error reset', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.update((_) {
+      throw Exception('test');
+    });
+    expect(await agent.error, isNotNull);
+    agent.resetError();
+    expect(await agent.error, isNull);
+  });
+
+  test('query with error', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.update((_) {
+      throw Exception('test');
+    });
+    expect(() async {
+      return await agent.read();
+    }, throwsA(isA<Exception>()));
+  });
+
+  test('deref after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.read();
+    }, throwsA(isA<StateError>()));
+  });
+
+  test('update after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.update((x) => x);
+    }, throwsA(isA<StateError>()));
+  });
+
+  test('query after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.read();
+    }, throwsA(isA<StateError>()));
+  });
+
+  test('exit after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.exit();
+    }, throwsA(isA<StateError>()));
+  });
+
+  test('err after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.error;
+    }, throwsA(isA<StateError>()));
+  });
+
+  test('reset error after kill', () async {
+    final Agent<int> agent = await Agent.create(() => 1);
+    agent.kill();
+    expect(() async {
+      await agent.resetError();
+    }, throwsA(isA<StateError>()));
   });
 }


### PR DESCRIPTION
* Adds `Agent.error` and `Agent.resetError`.
* Adds protection from talking to killed Agents.
* Updated naming of methods based on feedback:
  - deref -> read
  - query -> **eliminated for read**
  - create -> **eliminated for new create**
  - createWithResult -> create
  - send -> update